### PR TITLE
Add trim

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ let g:leaderf_github_stars_username='your github username'
 let g:leaderf_github_stars_maxline=80
 
 " Optional. Higher rate limit when using token
-let g:leaderf_github_stars_maxline = 'your github token'
+let g:leaderf_github_stars_github_token = 'your github token'
 ```
 Try:
 ```Vim

--- a/autoload/leaderf/Stars.vim
+++ b/autoload/leaderf/Stars.vim
@@ -4,7 +4,7 @@ endif
 
 let g:leaderf_github_stars_username = get(
       \g:, 'leaderf_github_stars_username',
-      \ executable('git') ? system('git config --global user.name') : expand('$USER'))
+      \ executable('git') ? trim(system('git config --global user.name')) : expand('$USER'))
 
 
 exec g:Lf_py "import vim, sys, os.path"


### PR DESCRIPTION
sorry for my disturbance!
i read <https://github.com/honza/vim-snippets/blob/d4c285e8e7b482db810f453a308d45f259facbf9/plugin/vimsnippets.vim#L14>, and find <https://github.com/bennyyip/LeaderF-github-stars/blob/982101a18e3d15d4313c656481381c1dc7d430fa/autoload/leaderf/Stars.vim#L7> exists some bug.

```{.vim}
echo system('git config --global user.name')
```

will return
![image](https://user-images.githubusercontent.com/32936898/94022301-89d60a00-fde7-11ea-8be6-a061174f17fe.png)

there exists a "\n" in the last character of the string.

`trim()` will remove the invisiable character of the string.

```{.vim}
echo trim(system('git config --global user.name'))
```

![image](https://user-images.githubusercontent.com/32936898/94024764-5ea0ea00-fdea-11ea-91a1-1b0f4ab51fb3.png)

Thanks!